### PR TITLE
Bugfix for Nullable exception in TransformVisitor.IsNull

### DIFF
--- a/Main/Source/Effort/Internal/DbCommandTreeTransformation/TransformVisitor.IsNull.cs
+++ b/Main/Source/Effort/Internal/DbCommandTreeTransformation/TransformVisitor.IsNull.cs
@@ -38,9 +38,16 @@ namespace Effort.Internal.DbCommandTreeTransformation
         {
             Expression source = this.Visit(expression.Argument);
 
-            if (source.Type.IsValueType && !TypeHelper.IsNullable(source.Type))
+            if (source.Type.IsValueType)
             {
-                return Expression.Constant(false);
+                if (!TypeHelper.IsNullable(source.Type))
+                {
+                    return Expression.Constant(false);
+                }
+                else
+                {
+                    return Expression.Equal(Expression.Convert(source, typeof(object)), Expression.Constant(null));
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes a bug where Expression.Equal is called with a Nullable Argument and throws and Exception, because int? and null are not of the same type.